### PR TITLE
Add Toolchain for CologneChips GateMateFPGA and add GateMate Eval. Board

### DIFF
--- a/oneware-packages.json
+++ b/oneware-packages.json
@@ -17,6 +17,12 @@
     },
     {
       "manifestUrl": "https://raw.githubusercontent.com/one-ware/OneWare.CoreMax10/main/oneware-package.json"
+    },
+    {
+      "manifestUrl": "https://raw.githubusercontent.com/swittlich/OneWare.CC-Toolchain/main/oneware-extension.json"
+    },
+    {
+      "manifestUrl": "https://raw.githubusercontent.com/swittlich/OneWare.GateMate/main/oneware-package.json"
     }
   ]
 }


### PR DESCRIPTION
I have written two plugins that make it possible to use the GateMateFPGAs from Cologne Chip. For easy integration for users, it would be nice if these were available directly in the plugin store.  

See: https://github.com/swittlich/OneWare.GateMate  and https://github.com/swittlich/OneWare.CC-Toolchain 