### PR TITLE
Add FEntwumS Netlist Viewer

### DIFF
--- a/oneware-packages.json
+++ b/oneware-packages.json
@@ -41,6 +41,9 @@
     },
     {
       "manifestUrl": "https://raw.githubusercontent.com/peterb12/OneWare.NandlandGo/main/oneware-package.json"
+    },
+    {
+      "manifestUrl": "https://raw.githubusercontent.com/FEntwumS/FEntwumS.NetlistViewer/refs/heads/master/oneware-extension.json"
     }
   ]
 }


### PR DESCRIPTION
This adds a hierarchical netlist viewer for VHDL, Verilog and some SystemVerilog designs. Designs containing Verilog and SystemVerilog may work, all other mixtures of HDLs will currently not work.

The plugin itself is most definitely not bug-free, this will improve with user feedback